### PR TITLE
Version 2.38 (May 8, 2025)

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -64,6 +64,12 @@
           <h2>The Betavault Changelog</h2>
           <p>An easy way to view the updates going on in Betavault.</p>
           <br>
+          <h3>Version 2.38 - May 8, 2025</h3>
+          <p>This update contains bug fixes.</p>
+          <ul>
+            <li>Infobox bug fixed on downloads page</li>
+          </ul>
+          <br>
           <h3>Version 2.37 - May 7, 2025</h3>
           <p>This update contains big website updates, including new builds, minor changes, and more tools!</p>
           <ul>

--- a/changelog.html
+++ b/changelog.html
@@ -65,9 +65,13 @@
           <p>An easy way to view the updates going on in Betavault.</p>
           <br>
           <h3>Version 2.38 - May 8, 2025</h3>
-          <p>This update contains bug fixes.</p>
+          <p>Bug Fixes, new builds, new tools, and the array.</p>
           <ul>
             <li>Infobox bug fixed on downloads page</li>
+            <li>Light Mode now works on every page.</li>
+            <li>Array Updated</li>
+            <li>Added Virtualbox to tools.</li>
+            <li>Added Windows 10 build 9906 to the Windows 10 builds page</li>
           </ul>
           <br>
           <h3>Version 2.37 - May 7, 2025</h3>

--- a/download.html
+++ b/download.html
@@ -70,6 +70,7 @@
           </p>
           <ul>
             <li><a href="/betavault/downloads/11.html">Windows 11 Beta Builds</a></li>
+            <li><a href="/betavault/downloads/10.html">Windows 10 Beta Builds</a></li>
             <li><a href="/betavault/downloads/7.html">Windows 7 Beta Builds</a></li>
             <li><a href="/betavault/downloads/vista.html">Windows Vista Beta Builds</a></li>
             <li><a href="/betavault/downloads/xp.html">Windows XP Beta Builds</a></li>

--- a/download.html
+++ b/download.html
@@ -89,7 +89,6 @@
         </section>
 
         <!-- Information Box -->
-        <aside class="info-box">
           <aside class="info-box">
           <h3 class="featuredName">Loading...</h3>
           <p class="featuredDesc"></p>

--- a/downloads/1.html
+++ b/downloads/1.html
@@ -111,6 +111,6 @@
     <footer>
       <p>&copy; 2025 BetaVault. All rights reserved.</p>
     </footer>
-    <script src="./src/startup.js"></script>
+    <script src="/betavault/src/startup.js"></script>
   </body>
 </html>

--- a/downloads/10.html
+++ b/downloads/10.html
@@ -91,6 +91,6 @@
     <footer>
       <p>&copy; 2025 BetaVault. All rights reserved.</p>
     </footer>
-    <script src="./src/startup.js"></script>
+    <script src="/betavault/src/startup.js"></script>
   </body>
 </html>

--- a/downloads/10.html
+++ b/downloads/10.html
@@ -65,7 +65,7 @@
           <p>The version of Windows that brought back the start menu, and brought Windows into a new era.</p>
           <br/>
           <h2>Download Builds</h2>
-          <p>Currently there are 2 builds avaliable to downlaod.</p>
+          <p>Currently there are 3 builds avaliable to downlaod.</p>
           <p>
             If your planning on installing any of these builds on real hardware, you should probably
             get <a href="https://rufus.ie">Rufus</a> to flash the USB flash drive.
@@ -75,6 +75,7 @@
           <br/>
           <p>Windows 10 build 9780 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/EaSu0dxzZChGhXta4Y62SuMBNc1GD7VcoYrSfu1wLyiVpA?e=oSrtkb">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9780">Betawiki</a> </p>
           <p>Windows 10 build 9785 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/ERulX6r7AxNJkXfdrDCppYMBw5zYzOB5HJcDEV3ffbWuYQ?e=aWSp0O">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9785">Betawiki</a></p>
+          <p>Windows 10 build 9906 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/ERyztp_8iLdGrOD7holU9N8BlbHK8NHWBhREFmPHSzqneg?e=alDkPb">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9906">BetaWiki</a></p>
         </section>
 
         <aside class="info-box">

--- a/downloads/11.html
+++ b/downloads/11.html
@@ -110,6 +110,6 @@
     <footer>
       <p>&copy; 2025 BetaVault. All rights reserved.</p>
     </footer>
-    <script src="./src/startup.js"></script>
+    <script src="/betavault/src/startup.js"></script>
   </body>
 </html>

--- a/downloads/7.html
+++ b/downloads/7.html
@@ -73,6 +73,10 @@
             <li>Error with something on our end.</li>
           </ul>
         </section>
+      </div>
+
+
+        <div class="info-box">
         <aside class="info-box">
           <h3>Featured Version: Windows 7 Build 7000</h3>
           <p>

--- a/downloads/tools.html
+++ b/downloads/tools.html
@@ -64,10 +64,11 @@
           <p>These are general tools you can use to make your expierence much better, these tools include VMware, Virtualbox, Drivers, USB flashing tools, and more!</p>
           <br/>
           <h2>Download Tools</h2>
-          <p>Currently there are 2 tools avaliable to downlaod.</p>
+          <p>Currently there are 3 tools avaliable to downlaod.</p>
           <br>
           <p>ShowHideControls <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/EWXjkOOllwFFsllKVHouP-gBqhaWhKtyDeReV0VTWh436Q?e=iPnOCE">Download</a> </p>
           <p>VMware Workstation <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/EZRNhif8PZ1BgxF3QeTBoYMBaYGE9WIvKIStFSN4xx5Q3A?e=hy4duo">Download</a> </p>
+          <p>Virtualbox <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/ESRc2AegIrpNunGXCgLCBgUBJg2Wz-fM7FOi01_CyOh-IQ?e=7huKY4">Download</a> </p>
         </section>
 
         <aside class="info-box">

--- a/downloads/tools.html
+++ b/downloads/tools.html
@@ -85,6 +85,6 @@
     <footer>
       <p>&copy; 2025 BetaVault. All rights reserved.</p>
     </footer>
-    <script src="/src/startup.js"></script>
+    <script src="/betavault/src/startup.js"></script>
   </body>
 </html>

--- a/downloads/xp.html
+++ b/downloads/xp.html
@@ -83,6 +83,6 @@
     <footer>
       <p>&copy; 2025 BetaVault. All rights reserved.</p>
     </footer>
-    <script src="./src/startup.js"></script>
+    <script src="/betavault/src/startup.js"></script>
   </body>
 </html>

--- a/src/featured.js
+++ b/src/featured.js
@@ -37,7 +37,14 @@ const availableFeaturedOS = [
     name: "Ubuntu 4.10",
     desc: "The first version of Ubuntu, starting a new open-source linux distro enjoyed by millions today.",
     codename: "Warty Warthog",
-    build: 4.10
+    build: "4.10"
+  },
+
+  {
+    name: "Windows 10 build 9906",
+    desc: "This is a build of Windows 10 that has some minor changes such as new Photos app UI, and the camera was taken out of a beta.",
+    codename: "Threshold",
+    build: 9906
   },
 ];
 


### PR DESCRIPTION
# Version 2.38 (May 8, 2025)

## Bug Fixes, new builds, new tools, and the array.

- Infobox bug fixed on downloads page
- Light Mode now works on every page.
- Array Updated
- Added Virtualbox to tools.
- Added Windows 10 build 9906 to the Windows 10 builds page

***
# why am I updating this site every day
## because well, there's only 14 days of school and im bored.