### PR TITLE
Version 2.40 - May 12, 2025

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -64,6 +64,12 @@
           <h2>The Betavault Changelog</h2>
           <p>An easy way to view the updates going on in Betavault.</p>
           <br>
+          <h3>Version 2.39 - May 9, 2025</h3>
+          <p>This could be the smallest update on Betavault ever.</p>
+          <ul>
+            <li>Bug Fixes</li>
+          </ul>
+          <br>
           <h3>Version 2.38 - May 8, 2025</h3>
           <p>Bug Fixes, new builds, new tools, and the array.</p>
           <ul>

--- a/changelog.html
+++ b/changelog.html
@@ -69,6 +69,7 @@
           <ul>
             <li>Bug Fixed in infoboxes (release dates now show)</li>
             <li>Windows 10 Build 9860, and 9879 added</li>
+            <li>Updated the infobox on the Windows 10 page to use the random infobox array</li>
           </ul>
           <br>
           <h3>Version 2.39 - May 9, 2025</h3>

--- a/changelog.html
+++ b/changelog.html
@@ -64,6 +64,13 @@
           <h2>The Betavault Changelog</h2>
           <p>An easy way to view the updates going on in Betavault.</p>
           <br>
+          <h3>Version 2.40 - May 12, 2025</h3>
+          <p>This update brings QOL and New Builds to BetaVault.</p>
+          <ul>
+            <li>Bug Fixed in infoboxes (release dates now show)</li>
+            <li>Windows 10 Build 9860, and 9879 added</li>
+          </ul>
+          <br>
           <h3>Version 2.39 - May 9, 2025</h3>
           <p>This could be the smallest update on Betavault ever.</p>
           <ul>

--- a/downloads/10.html
+++ b/downloads/10.html
@@ -73,18 +73,20 @@
           <p>Keep in mind that some of these builds are in UUP Dump files, so you'll need to run that
             first.</p>
           <br/>
-          <p>Windows 10 build 9780 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/EaSu0dxzZChGhXta4Y62SuMBNc1GD7VcoYrSfu1wLyiVpA?e=oSrtkb">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9780">Betawiki</a> </p>
+          <p>Windows 10 build 9780 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/EaSu0dxzZChGhXta4Y62SuMBNc1GD7VcoYrSfu1wLyiVpA?e=oSrtkb">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9780">Betawiki</a></p>
           <p>Windows 10 build 9785 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/ERulX6r7AxNJkXfdrDCppYMBw5zYzOB5HJcDEV3ffbWuYQ?e=aWSp0O">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9785">Betawiki</a></p>
+          <p>Windows 10 build 9860 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/EQY9_-6mLPNDnEbuyMr-SXUBiZ0-viqDfDkk-wHuLTWHJA?e=3mgaOe">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9860">Betawiki</a></p>
+          <p>Windows 10 build 9879 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/Ecin2690FKpBhyS6xJsdULcBFKScNYj1I0TN9ujBfLA69Q?e=8LfFZz">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9879">Betawiki</a></p>
           <p>Windows 10 build 9906 <a href="https://katyisd-my.sharepoint.com/:u:/g/personal/k1637252_students_katyisd_org/ERyztp_8iLdGrOD7holU9N8BlbHK8NHWBhREFmPHSzqneg?e=alDkPb">Download</a> <a href="https://betawiki.net/wiki/Windows_10_build_9906">BetaWiki</a></p>
         </section>
 
         <aside class="info-box">
-          <h3>Featured Build: Windows 10 build 9780</h3>
-          <p>Brought back the start menu</p>
+           <h3 class="featuredName">Loading...</h3>
+          <p class="featuredDesc"></p>
           <ul>
-            <li>Compiled on: June 22, 2014</li>
-            <li>Codename: Threshold</li>
-            <li>Architecture: x86</li>
+            <li class="featuredReleaseDate"></li>
+            <li class="featuredBuild"></li>
+            <li class="featuredCodename"></li>
           </ul>
         </aside>
       </div>
@@ -93,5 +95,6 @@
       <p>&copy; 2025 BetaVault. All rights reserved.</p>
     </footer>
     <script src="/betavault/src/startup.js"></script>
+    <script src="/betavault/src/featured.js" defer></script>
   </body>
 </html>

--- a/src/featured.js
+++ b/src/featured.js
@@ -37,6 +37,7 @@ const availableFeaturedOS = [
     name: "Ubuntu 4.10",
     desc: "The first version of Ubuntu, starting a new open-source linux distro enjoyed by millions today.",
     codename: "Warty Warthog",
+    releaseDate: new Date(2004,10,20),
     build: "4.10",
   },
 
@@ -44,7 +45,16 @@ const availableFeaturedOS = [
     name: "Windows 10 build 9906",
     desc: "This is a build of Windows 10 that has some minor changes such as new Photos app UI, and the camera was taken out of a beta.",
     codename: "Threshold",
+    releaseDate: new Date(2014,12,9),
     build: 9906,
+  },
+
+  {
+    name: "Windows 10 build 9860",
+    desc: "This build of Windows 10 introduced a new XAML start menu, and hidden apps.",
+    codename: "Threshold",
+    releaseDate: new Date(2014,10,8),
+    build: 9860,
   },
 ];
 


### PR DESCRIPTION
# v2.40
## Released on May 12, 2025

This update brings QOL (Quality of Life) and new builds to BetaVault.

Here is a list of things added.

- Bug Fixes (release dates now show in the infoboxes)
- 2 Builds added (Windows 10 Build 9860 and 9879)
- Updated the infobox on the Windows 10 page to use random featured OS array.